### PR TITLE
Change tab settings to match style of the Pony stdlib.

### DIFF
--- a/static/web.js
+++ b/static/web.js
@@ -567,6 +567,10 @@
 
         session.setMode("ace/mode/rust");
 
+        // Match the tab style of the Pony standard library.
+        session.setTabSize(2);
+        session.setUseSoftTabs(true);
+
         mode = optionalLocalStorageGetItem("keyboard");
         if (mode !== null) {
             set_keyboard(editor, mode);


### PR DESCRIPTION
This PR changes the tab settings of the Pony Playpen editor to use soft tabs of 2 spaces, matching the tab style of the Pony standard library.